### PR TITLE
Task: Modify "Todo to Issue" action to run on pushes to main

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -2,7 +2,7 @@ name: "Run TODO to Issue"
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 jobs:
   build:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -1,5 +1,8 @@
 name: "Run TODO to Issue"
-on: [ "push" ]
+on:
+  push:
+    branches:
+      - 'main'
 jobs:
   build:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Actualmente, la GitHub Action de "Todo to Issue" se corre cada vez que *pusheamos* al repo. Esto termina significando que podemos resolver erróneamente issues que en realidad siguen estando, ya que al borrar un TODO en una rama diferente a `main`, se corre la acción y cierra el issue, aunque en realidad el issue sigue estando en `main` y quizá la rama nunca se *mergee*.

Este PR modifica la GitHub Action para que corra solamente cuando se pushee a `main` —o sea, cuando se mergeen PRs a `main`—. De esta forma, los issues de TODOs siguen vivos mientras no se haya borrado el TODO en `main` —y se cerrarán automáticamente cuando se *mergee* cual sea el PR a `main`—.